### PR TITLE
Dockerize build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,13 @@ RUN fc-cache -fv;
 # install inotify-tools for monitoring / mimicing latexmk -pvc
 RUN apt-get install -y inotify-tools;
 
-# clone the repository
-RUN git clone https://github.com/tuc-osg/osg-exam.git ~/osg-exam;
+# copy repo contents into container
+COPY . /root/osg-exam
 
 # install class (as described in Readme.md, for now.)
 RUN mkdir -p $(kpsewhich -var-value=TEXMFHOME)/tex;
-RUN ln -s ~/osg-exam/osgexam $(kpsewhich -var-value=TEXMFHOME)/tex/osgexam;
+RUN ln -s /root/osg-exam/osgexam $(kpsewhich -var-value=TEXMFHOME)/tex/osgexam;
 RUN texhash;
 
 # install latexmkrc for building later on
-RUN ln -s ~/osg-exam/osgexam/latexmkrc /root/.latexmkrc;
-
-WORKDIR /workdir
+RUN ln -s /root/osg-exam/osgexam/latexmkrc /root/.latexmkrc;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Start using tex distribution
+FROM texlive/texlive:latest
+
+# Install additional dependencies
+RUN apt-get update;
+
+# install python and openpyxl
+RUN apt-get install -y python3 python3-openpyxl;
+
+# install paratype font
+RUN apt-get install -y fonts-paratype;
+RUN fc-cache -fv;
+
+# install inotify-tools for monitoring / mimicing latexmk -pvc
+RUN apt-get install -y inotify-tools;
+
+# clone the repository
+RUN git clone https://github.com/tuc-osg/osg-exam.git ~/osg-exam;
+
+# install class (as described in Readme.md, for now.)
+RUN mkdir -p $(kpsewhich -var-value=TEXMFHOME)/tex;
+RUN ln -s ~/osg-exam/osgexam $(kpsewhich -var-value=TEXMFHOME)/tex/osgexam;
+RUN texhash;
+
+# install latexmkrc for building later on
+RUN ln -s ~/osg-exam/osgexam/latexmkrc /root/.latexmkrc;
+
+WORKDIR /workdir

--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,25 @@ This is the template for our exams, which relies on the [LaTeX exam class](https
 
 This is still work in progress.
 
-## Installation
+## Dockerized installation
+### Prerequisites
+- docker: `brew install --cask docker`
+
+### Procedure
+- build a docker image based on the provided Dockerfile: `docker build -t osg-exam .`
+  - `osg-exam` is the name of the image, that's your choice.
+- test with provided example exam:
+```bash
+cd doc
+docker run --rm -it -v .:/workdir osg-exam sh -c "latexmk osgexam-example.tex"
+```
+- from this point on, exams in any folder can be build via this command, just adapt `osgexam-example.tex` to the corresponding source file
+
+### TODOs
+- provide an easier way to invoke compliation
+- make use of `inotify-tools` to provide a `latexmk -pvc`-like experience
+
+## Local installation
 ### Prerequisites
 - Python >= 3.6
 - latexmk >= 4.61

--- a/doc/latexmkrc
+++ b/doc/latexmkrc
@@ -1,1 +1,0 @@
-../osgexam/latexmkrc

--- a/osgexam/osgexam.cls
+++ b/osgexam/osgexam.cls
@@ -477,7 +477,7 @@ if sys.argv[1] == 'serie':
 \LoadClass{exam}
 \AtEndPreamble{
   \usepackage{fontspec}
-  \setmainfont{PT Serif} %{etwa: Times New Roman}
+  \setmainfont{PT-Serif} %{etwa: Times New Roman}
   % ToDo: Passende Sans- und Mono-Fonts setzen?
 }
 %%%%%%%%%%%%%% Sprache %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Added Dockerfile and Readme section to create reproducible build environments.

Probably it would be a good idea to provide this in a second branch for now, but I am unsure how to do this. Hence, this is just a draft pull request for now.

Changing `\setmainfont` was necessary to find the PT fonts in the docker environment, probably since macOS is a little bit less strict here.